### PR TITLE
Remove env.js from repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ dependencies you can execute all tests with the command above.
 ## Supabase configuration
 
 `env.js` is listed in `.gitignore` so it will not be committed.
+Copy `env.js.example` to `env.js` and fill in your own `SUPABASE_URL` and
+`SUPABASE_KEY` values. The application imports this file in
+`supabaseClient.js`, so when deploying to production you must provide your own
+`env.js` alongside the source.
 
 The project loads the Supabase client library from jsDelivr and pins it to a
 specific version for stability. If you update the library, modify

--- a/env.js
+++ b/env.js
@@ -1,2 +1,0 @@
-export const SUPABASE_URL = 'https://dbdnvjbkotlyarsfmtjn.supabase.co';
-export const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRiZG52amJrb3RseWFyc2ZtdGpuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY5NTUxNTUsImV4cCI6MjA2MjUzMTE1NX0.cQXd9NQQbEQ5tWAeQ2pJWIoGkQjAbVs4tOQAUeDCET0';

--- a/env.js.example
+++ b/env.js.example
@@ -1,0 +1,2 @@
+export const SUPABASE_URL = '<your-supabase-url>';
+export const SUPABASE_KEY = '<your-supabase-key>';

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -1,5 +1,7 @@
 
 import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.7/+esm';
+// `env.js` is ignored by Git. Copy `env.js.example` locally and provide the file
+// separately when deploying to production.
 import { SUPABASE_URL, SUPABASE_KEY } from './env.js';
 
 export const supabase = createClient(


### PR DESCRIPTION
## Summary
- delete `env.js` and add `env.js.example`
- document how to create `env.js`
- note in `supabaseClient.js` that `env.js` is provided separately

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881ef9d7e40832382cdd74ec314ca33