### PR TITLE
Refactor ticket pages to use DOM APIs

### DIFF
--- a/Soccer/fcseoul.html
+++ b/Soccer/fcseoul.html
@@ -33,12 +33,13 @@
   <script type="module">
     import { supabase } from "../supabaseClient.js";
     import { createSoccerTicket } from "../soccerTicket.js";
+    import { loadHeader } from "../headerLoader.js";
 
     const TEAM_NAME = 'FC 서울';
 
     async function fetchTickets() {
       const list = document.getElementById('ticket-list');
-      list.innerHTML = '불러오는 중...';
+      list.textContent = '불러오는 중...';
 
       const { data, error } = await supabase
         .from('tickets')
@@ -47,31 +48,26 @@
 
       if (error) {
         console.error('에러:', error.message);
-        list.innerHTML = '데이터를 불러오는 중 오류가 발생했습니다.';
+        list.textContent = '데이터를 불러오는 중 오류가 발생했습니다.';
         return;
       }
 
       if (!data || data.length === 0) {
-        list.innerHTML = '등록된 티켓이 없습니다.';
+        list.textContent = '등록된 티켓이 없습니다.';
         return;
       }
 
-      list.innerHTML = ''; // 기존 내용 초기화
+      list.textContent = ''; // 기존 내용 초기화
 
       data.forEach(ticket => {
         const div = createSoccerTicket(ticket);
         list.appendChild(div);
       });
-      });
     }
 
     fetchTickets();
     
-       fetch("../Soccer-header.html")
-      .then(response => response.text())
-      .then(data => {
-        document.getElementById("header-placeholder").innerHTML = data;
-      });
+    loadHeader('../Soccer-header.html');
   </script>
 </body>
 </html>

--- a/Soccer/ulsanhyundai.html
+++ b/Soccer/ulsanhyundai.html
@@ -31,11 +31,13 @@
 
   <script type="module">
     import { supabase } from "../supabaseClient.js";
+    import { createSoccerTicket } from "../soccerTicket.js";
+    import { loadHeader } from "../headerLoader.js";
     const TEAM_NAME = '울산 현대';
 
     async function fetchTickets() {
       const list = document.getElementById('ticket-list');
-      list.innerHTML = '불러오는 중...';
+      list.textContent = '불러오는 중...';
 
       const { data, error } = await supabase
         .from('tickets')
@@ -44,42 +46,25 @@
 
       if (error) {
         console.error('에러:', error.message);
-        list.innerHTML = '데이터를 불러오는 중 오류가 발생했습니다.';
+        list.textContent = '데이터를 불러오는 중 오류가 발생했습니다.';
         return;
       }
 
       if (!data || data.length === 0) {
-        list.innerHTML = '등록된 티켓이 없습니다.';
+        list.textContent = '등록된 티켓이 없습니다.';
         return;
       }
 
-      list.innerHTML = ''; // 기존 내용 초기화
-
+      list.textContent = '';
       data.forEach(ticket => {
-        const div = document.createElement('div');
-        div.className = 'ticket';
-        div.innerHTML = `
-          <strong>경기 날짜:</strong> ${ticket.match_date} <br>
-          <strong>경기 시간:</strong> ${ticket.match_time}<br>
-          <strong>경기장:</strong> ${ticket.stadium}<br>
-          <strong>좌석 등급:</strong> ${ticket.seat_grade}<br>
-          <strong>좌석 번호:</strong> ${ticket.seat_number}<br>
-          <strong>티켓 당 가격:</strong> ${ticket.price}원<br>
-          <strong>판매 수량:</strong> ${ticket.ticket_count}장<br>
-          <strong>연락처:</strong> ${ticket.contact_method}<br>
-          <strong>추가 설명:</strong> ${ticket.additional_info || '없음'}
-        `;
+        const div = createSoccerTicket(ticket);
         list.appendChild(div);
       });
     }
 
     fetchTickets();
     
-       fetch("../Soccer-header.html")
-      .then(response => response.text())
-      .then(data => {
-        document.getElementById("header-placeholder").innerHTML = data;
-      });
+    loadHeader('../Soccer-header.html');
   </script>
 </body>
 </html>

--- a/baseball/kiwoom.html
+++ b/baseball/kiwoom.html
@@ -74,6 +74,8 @@
 
 <script type="module">
   import { supabase } from '../supabaseClient.js';
+  import { createTicketCard } from '../ticketCard.js';
+  import { loadHeader } from '../headerLoader.js';
 
   document.addEventListener("DOMContentLoaded", async () => {
     const resultContainer = document.getElementById("ticket-results");
@@ -86,37 +88,22 @@
 
     if (error) {
       console.error('에러:', error.message);
-      resultContainer.innerHTML = '데이터를 불러오는 중 오류가 발생했습니다.';
+      resultContainer.textContent = '데이터를 불러오는 중 오류가 발생했습니다.';
       return;
     }
 
     if (!data || data.length === 0) {
-      resultContainer.innerHTML = '등록된 티켓이 없습니다.';
+      resultContainer.textContent = '등록된 티켓이 없습니다.';
       return;
     }
 
-    resultContainer.innerHTML = '';
+    resultContainer.textContent = '';
     data.forEach(ticket => {
-      const card = document.createElement("div");
-      card.className = "ticket-card";
-      card.innerHTML = `
-        <div class="ticket-opponent_team">vs ${ticket.opponent_team}</div>
-        <div class="ticket-location">${ticket.section} | ${ticket.row}열</div>
-        <div class="ticket-subinfo">${ticket.match_date} ${ticket.match_time}</div>
-        <div class="ticket-subinfo">${ticket.seat_grade} / ${ticket.ticket_count}매 / ${ticket.trade_method}</div>
-        <div class="ticket-price">${ticket.price.toLocaleString()}원</div>
-      `;
-      card.addEventListener('click', () => {
-        window.location.href = `/payment.html?ticket_id=${ticket.id}`;
-      });
+      const card = createTicketCard(ticket);
       resultContainer.appendChild(card);
     });
   });
-  fetch("../Baseball-header.html")
-    .then(response => response.text())
-    .then(data => {
-      document.getElementById("header-placeholder").innerHTML = data;
-    });
+  loadHeader('../Baseball-header.html');
 </script>
 </body>
 </html>

--- a/baseball/lg.html
+++ b/baseball/lg.html
@@ -74,6 +74,8 @@
 
 <script type="module">
   import { supabase } from '../supabaseClient.js';
+  import { createTicketCard } from '../ticketCard.js';
+  import { loadHeader } from '../headerLoader.js';
 
   document.addEventListener("DOMContentLoaded", async () => {
     const resultContainer = document.getElementById("ticket-results");
@@ -86,37 +88,22 @@
 
     if (error) {
       console.error('에러:', error.message);
-      resultContainer.innerHTML = '데이터를 불러오는 중 오류가 발생했습니다.';
+      resultContainer.textContent = '데이터를 불러오는 중 오류가 발생했습니다.';
       return;
     }
 
     if (!data || data.length === 0) {
-      resultContainer.innerHTML = '등록된 티켓이 없습니다.';
+      resultContainer.textContent = '등록된 티켓이 없습니다.';
       return;
     }
 
-    resultContainer.innerHTML = '';
+    resultContainer.textContent = '';
     data.forEach(ticket => {
-      const card = document.createElement("div");
-      card.className = "ticket-card";
-      card.innerHTML = `
-        <div class="ticket-opponent_team">vs ${ticket.opponent_team}</div>
-        <div class="ticket-location">${ticket.section} | ${ticket.row}열</div>
-        <div class="ticket-subinfo">${ticket.match_date} ${ticket.match_time}</div>
-        <div class="ticket-subinfo">${ticket.seat_grade} / ${ticket.ticket_count}매 / ${ticket.trade_method}</div>
-        <div class="ticket-price">${ticket.price.toLocaleString()}원</div>
-      `;
-      card.addEventListener('click', () => {
-        window.location.href = `/payment.html?ticket_id=${ticket.id}`;
-      });
+      const card = createTicketCard(ticket);
       resultContainer.appendChild(card);
     });
   });
-  fetch("../Baseball-header.html")
-    .then(response => response.text())
-    .then(data => {
-      document.getElementById("header-placeholder").innerHTML = data;
-    });
+  loadHeader('../Baseball-header.html');
 </script>
 </body>
 </html>

--- a/baseball/lotte.html
+++ b/baseball/lotte.html
@@ -75,6 +75,7 @@
 <script type="module">
   import { supabase } from '../supabaseClient.js';
   import { createTicketCard } from "../ticketCard.js";
+  import { loadHeader } from "../headerLoader.js";
 
   document.addEventListener("DOMContentLoaded", async () => {
     const resultContainer = document.getElementById("ticket-results");
@@ -87,26 +88,22 @@
 
     if (error) {
       console.error('에러:', error.message);
-      resultContainer.innerHTML = '데이터를 불러오는 중 오류가 발생했습니다.';
+      resultContainer.textContent = '데이터를 불러오는 중 오류가 발생했습니다.';
       return;
     }
 
     if (!data || data.length === 0) {
-      resultContainer.innerHTML = '등록된 티켓이 없습니다.';
+      resultContainer.textContent = '등록된 티켓이 없습니다.';
       return;
     }
 
-    resultContainer.innerHTML = '';
+    resultContainer.textContent = '';
     data.forEach(ticket => {
       const card = createTicketCard(ticket);
       resultContainer.appendChild(card);
     });
     });
-  fetch("../Baseball-header.html")
-    .then(response => response.text())
-    .then(data => {
-      document.getElementById("header-placeholder").innerHTML = data;
-    });
+  loadHeader('../Baseball-header.html');
 </script>
 </body>
 </html>

--- a/headerLoader.js
+++ b/headerLoader.js
@@ -1,0 +1,14 @@
+export async function loadHeader(path) {
+  const response = await fetch(path);
+  const html = await response.text();
+  const placeholder = document.getElementById('header-placeholder');
+  if (!placeholder) return;
+  // Use DOMPurify if available, otherwise fallback to direct insertion
+  if (window.DOMPurify) {
+    placeholder.innerHTML = DOMPurify.sanitize(html);
+  } else {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    placeholder.replaceChildren(...doc.body.childNodes);
+  }
+}

--- a/stadiumSeats.js
+++ b/stadiumSeats.js
@@ -271,7 +271,7 @@ function updateSeatOptions(stadiumSelectId, seatSelectId) {
 
   stadiumSelect.addEventListener("change", () => {
     const name = stadiumSelect.value.replace(/\(.*?\)/g, "").trim();
-    seatSelect.innerHTML = "";
+    seatSelect.textContent = "";
     if (stadiumSeats[name]) {
       stadiumSeats[name].forEach(seat => {
         const opt = document.createElement("option");
@@ -280,7 +280,10 @@ function updateSeatOptions(stadiumSelectId, seatSelectId) {
         seatSelect.appendChild(opt);
       });
     } else {
-      seatSelect.innerHTML = '<option value="">선택 가능한 좌석 없음</option>';
+      const opt = document.createElement("option");
+      opt.value = "";
+      opt.textContent = "선택 가능한 좌석 없음";
+      seatSelect.appendChild(opt);
     }
   });
 }


### PR DESCRIPTION
## Summary
- add `headerLoader.js` to safely load shared HTML headers
- switch stadium seat dropdowns to DOM API
- render baseball and soccer ticket pages with reusable card builders
- clean up repeated header fetch logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881efa421f08323a6f5e20b6a6e227a