### PR TITLE
Add account settings page

### DIFF
--- a/Baseball-header.html
+++ b/Baseball-header.html
@@ -7,6 +7,7 @@
       <li><a href="/submit.html">티켓 등록</a></li>
       <li><a href="/tickets.html">등록된 티켓</a></li>
       <li><a href="/about.html">소개</a></li>
+      <li><a href="/account-settings.html">계정 설정</a></li>
       <li class="dropdown">
         <span class="dropdown-toggle">스포츠</span>
         <ul class="dropdown-menu">

--- a/Soccer-header.html
+++ b/Soccer-header.html
@@ -5,6 +5,7 @@
       <li><a href="/submit.html">티켓 등록</a></li>
       <li><a href="/tickets.html">등록된 티켓</a></li>
       <li><a href="/about.html">소개</a></li>
+      <li><a href="/account-settings.html">계정 설정</a></li>
       <li class="dropdown">
         <span class="dropdown-toggle">스포츠</span>
         <ul class="dropdown-menu">

--- a/account-settings.html
+++ b/account-settings.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <title>계정 설정</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <a href="login.html" id="login-button" style="position: absolute; top: 20px; right: 20px; padding: 10px 16px; background-color: #007BFF; color: white; text-decoration: none; border-radius: 6px;">로그인 / 회원가입</a>
+  <header style="text-align:center; margin-bottom:20px;">
+    <a href="index.html" style="text-decoration:none; font-size:24px;">🎟️</a>
+    <h1 style="margin:10px 0;">계정 설정</h1>
+  </header>
+  <section style="max-width:400px; margin:0 auto;">
+    <form id="password-form" style="margin-bottom:30px;">
+      <h2>비밀번호 변경</h2>
+      <input type="password" id="new-password" placeholder="새 비밀번호" required style="width:100%; padding:8px; margin:6px 0;" />
+      <input type="password" id="confirm-password" placeholder="새 비밀번호 확인" required style="width:100%; padding:8px; margin:6px 0;" />
+      <button type="submit" style="width:100%; padding:10px;">변경하기</button>
+      <div id="password-result" style="margin-top:10px; text-align:center;"></div>
+    </form>
+    <form id="delete-form">
+      <h2>계정 삭제</h2>
+      <button type="submit" style="width:100%; padding:10px; background-color:#dc3545; color:white;">계정 삭제</button>
+      <div id="delete-result" style="margin-top:10px; text-align:center;"></div>
+    </form>
+  </section>
+
+  <script type="module" src="accountSettings.js"></script>
+  <script type="module" src="sessionCheck.js"></script>
+</body>
+</html>

--- a/accountSettings.js
+++ b/accountSettings.js
@@ -1,0 +1,45 @@
+import { supabase } from './supabaseClient.js';
+
+const passwordForm = document.getElementById('password-form');
+const deleteForm = document.getElementById('delete-form');
+
+passwordForm?.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const newPassword = document.getElementById('new-password').value;
+  const confirmPassword = document.getElementById('confirm-password').value;
+  const result = document.getElementById('password-result');
+
+  if (newPassword !== confirmPassword) {
+    result.textContent = '❌ 비밀번호가 일치하지 않습니다.';
+    return;
+  }
+
+  const { error } = await supabase.auth.updateUser({ password: newPassword });
+  result.textContent = error ? `❌ ${error.message}` : '✅ 비밀번호가 변경되었습니다.';
+});
+
+deleteForm?.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  if (!confirm('정말로 계정을 삭제하시겠습니까? 이 동작은 되돌릴 수 없습니다.')) return;
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  const result = document.getElementById('delete-result');
+  if (error || !user) {
+    result.textContent = '❌ 사용자 정보를 확인할 수 없습니다.';
+    return;
+  }
+
+  const { error: delError } = await supabase.auth.admin.deleteUser(user.id);
+  if (delError) {
+    result.textContent = `❌ ${delError.message}`;
+    return;
+  }
+
+  await supabase.auth.signOut();
+  result.textContent = '✅ 계정이 삭제되었습니다.';
+  window.location.href = 'index.html';
+});

--- a/mypage.html
+++ b/mypage.html
@@ -49,6 +49,7 @@
       <a href="submit.html">티켓 등록</a>
       <a href="tickets.html">등록된 티켓</a>
       <a href="about.html">소개</a>
+      <a href="account-settings.html">계정 설정</a>
     </nav>
   </header>
 


### PR DESCRIPTION
## Summary
- add a new page `account-settings.html` for user password changes and account deletion
- implement password update and deletion logic in `accountSettings.js`
- link to account settings from the common headers and from the mypage navigation

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688219b0512083238da34928079eeee4