### PR TITLE
Integrate payment SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ web_modules/
 .env.*
 !.env.example
 env.js
+paymentConfig.js
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ Copy `env.js.example` to `env.js` and fill in your own `SUPABASE_URL` and
 The project loads the Supabase client library from jsDelivr and pins it to a
 specific version for stability. If you update the library, modify
 `supabaseClient.js` to reference the desired version (currently `@supabase/supabase-js@2.39.7`).
+
+## Payment configuration
+
+`paymentConfig.js` is also ignored by Git. Copy `paymentConfig.js.example` to
+`paymentConfig.js` and supply your payment SDK client key. The `payment.js`
+module imports this file when initiating the payment widget.

--- a/payment.html
+++ b/payment.html
@@ -36,40 +36,7 @@
   <div id="ticket-info">불러오는 중...</div>
   <button id="purchase-btn" style="display:none;">구매하기</button>
 
-<script type="module">
-import { supabase } from './supabaseClient.js';
-
-const params = new URLSearchParams(window.location.search);
-const ticketId = params.get('ticket_id');
-const infoDiv = document.getElementById('ticket-info');
-const purchaseBtn = document.getElementById('purchase-btn');
-
-if (!ticketId) {
-  infoDiv.textContent = '티켓 정보가 없습니다.';
-} else {
-  const { data, error } = await supabase
-    .from('tickets')
-    .select('*')
-    .eq('id', ticketId)
-    .single();
-
-  if (error || !data) {
-    infoDiv.textContent = '티켓을 불러오는 중 오류가 발생했습니다.';
-  } else {
-    infoDiv.innerHTML = `
-      <h2>${data.team} vs ${data.opponent_team}</h2>
-      <p>${data.stadium}</p>
-      <p>${data.match_date} ${data.match_time}</p>
-      <p>${data.seat_grade} / ${data.section} / ${data.row}</p>
-      <p><strong>${Number(data.price).toLocaleString()}원</strong></p>
-    `;
-    purchaseBtn.style.display = 'inline-block';
-  }
-}
-
-purchaseBtn.addEventListener('click', () => {
-  alert('구매가 완료되었습니다. 실제 결제 기능은 구현되어 있지 않습니다.');
-});
-</script>
+<script src="https://js.tosspayments.com/v1"></script>
+<script type="module" src="payment.js"></script>
 </body>
 </html>

--- a/payment.js
+++ b/payment.js
@@ -1,0 +1,90 @@
+import { supabase } from './supabaseClient.js';
+// `paymentConfig.js` is ignored by Git. Copy `paymentConfig.js.example` locally and provide your own key.
+import { PAYMENT_CLIENT_KEY } from './paymentConfig.js';
+
+async function loadTicket() {
+  const params = new URLSearchParams(window.location.search);
+  const ticketId = params.get('ticket_id');
+  const infoDiv = document.getElementById('ticket-info');
+  const purchaseBtn = document.getElementById('purchase-btn');
+
+  if (!ticketId) {
+    infoDiv.textContent = '티켓 정보가 없습니다.';
+    return;
+  }
+
+  const { data, error } = await supabase
+    .from('tickets')
+    .select('*')
+    .eq('id', ticketId)
+    .single();
+
+  if (error || !data) {
+    infoDiv.textContent = '티켓을 불러오는 중 오류가 발생했습니다.';
+    return;
+  }
+
+  infoDiv.innerHTML = `
+    <h2>${data.team} vs ${data.opponent_team}</h2>
+    <p>${data.stadium}</p>
+    <p>${data.match_date} ${data.match_time}</p>
+    <p>${data.seat_grade} / ${data.section} / ${data.row}</p>
+    <p><strong>${Number(data.price).toLocaleString()}원</strong></p>
+  `;
+
+  purchaseBtn.style.display = 'inline-block';
+  purchaseBtn.addEventListener('click', () => requestPayment(data));
+}
+
+async function createOrder(ticket) {
+  try {
+    const res = await fetch('/api/orders', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ticketId: ticket.id, amount: ticket.price })
+    });
+    if (!res.ok) throw new Error('network');
+    const { orderId } = await res.json();
+    return orderId;
+  } catch (e) {
+    console.error('주문 생성 실패:', e);
+  }
+}
+
+export async function verifyOrder(orderId, paymentKey, amount) {
+  try {
+    const res = await fetch('/api/orders/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orderId, paymentKey, amount })
+    });
+    if (!res.ok) throw new Error('network');
+    return await res.json();
+  } catch (e) {
+    console.error('결제 검증 실패:', e);
+  }
+}
+
+function requestPayment(ticket) {
+  if (!window.TossPayments) {
+    alert('결제 모듈을 불러오지 못했습니다.');
+    return;
+  }
+
+  createOrder(ticket).then(orderId => {
+    if (!orderId) return;
+
+    const toss = window.TossPayments(PAYMENT_CLIENT_KEY);
+    toss.requestPayment('카드', {
+      amount: ticket.price,
+      orderId,
+      orderName: `${ticket.team} vs ${ticket.opponent_team}`,
+      successUrl: `${window.location.origin}/verified.html`,
+      failUrl: window.location.href
+    }).catch(e => {
+      console.error('결제 실패:', e);
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', loadTicket);

--- a/paymentConfig.js.example
+++ b/paymentConfig.js.example
@@ -1,0 +1,1 @@
+export const PAYMENT_CLIENT_KEY = '<your-payment-client-key>';


### PR DESCRIPTION
## Summary
- use external payment widget on payment page
- add `payment.js` to handle ticket purchase and order calls
- store SDK keys in `paymentConfig.js` (ignored)
- document setup for payment keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688219c1892883238d304163e005826d