### PR TITLE
Add paginated tickets API and update listing page

### DIFF
--- a/functions/tickets/index.js
+++ b/functions/tickets/index.js
@@ -1,0 +1,43 @@
+import { serve } from 'https://deno.land/std@0.192.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL')
+const supabaseKey = Deno.env.get('SUPABASE_ANON_KEY')
+const supabase = createClient(supabaseUrl, supabaseKey)
+
+serve(async (req) => {
+  const { searchParams } = new URL(req.url)
+  const team = searchParams.get('team')
+  const stadium = searchParams.get('stadium')
+  const page = parseInt(searchParams.get('page') ?? '1')
+  const pageSize = parseInt(searchParams.get('page_size') ?? '10')
+
+  let query = supabase
+    .from('tickets')
+    .select('*', { count: 'exact' })
+    .order('match_date', { ascending: true })
+
+  if (team) {
+    query = query.eq('team', team)
+  }
+  if (stadium) {
+    query = query.eq('stadium', stadium)
+  }
+
+  const from = (page - 1) * pageSize
+  const to = from + pageSize - 1
+  query = query.range(from, to)
+
+  const { data, error, count } = await query
+
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    })
+  }
+
+  return new Response(JSON.stringify({ data, count }), {
+    headers: { 'Content-Type': 'application/json' }
+  })
+})

--- a/tickets.html
+++ b/tickets.html
@@ -201,36 +201,63 @@
 </header>
 <h1>티켓 목록</h1>
 <div id="ticket-results">불러오는 중...</div>
+<button id="load-more" style="display:none; margin:20px auto;">더 보기</button>
 
 <script type="module">
-  import { supabase } from './supabaseClient.js';
-  import { createTicketCard } from "./ticketCard.js";
+  import { SUPABASE_URL } from './env.js';
+  import { createTicketCard } from './ticketCard.js';
 
-  document.addEventListener("DOMContentLoaded", async () => {
-    const resultContainer = document.getElementById("ticket-results");
+  const resultContainer = document.getElementById('ticket-results');
+  const loadMoreBtn = document.getElementById('load-more');
+  const PAGE_SIZE = 10;
+  let page = 1;
 
-    const { data, error } = await supabase
-      .from("tickets")
-      .select("*")
-      .order("match_date", { ascending: true });
+  async function fetchTickets() {
+    const params = new URLSearchParams({ page, page_size: PAGE_SIZE });
+    const urlParams = new URLSearchParams(window.location.search);
+    const team = urlParams.get('team');
+    const stadium = urlParams.get('stadium');
+    if (team) params.append('team', team);
+    if (stadium) params.append('stadium', stadium);
 
-    if (error) {
-      console.error('에러:', error.message);
+    const res = await fetch(`${SUPABASE_URL}/functions/v1/tickets?${params}`);
+    if (!res.ok) {
       resultContainer.innerHTML = '데이터를 불러오는 중 오류가 발생했습니다.';
       return;
     }
+    const { data, count } = await res.json();
+
+    if (page === 1) {
+      resultContainer.innerHTML = '';
+    }
 
     if (!data || data.length === 0) {
-      resultContainer.innerHTML = '등록된 티켓이 없습니다.';
+      if (page === 1) {
+        resultContainer.innerHTML = '등록된 티켓이 없습니다.';
+      }
+      loadMoreBtn.style.display = 'none';
       return;
     }
 
-    resultContainer.innerHTML = '';
     data.forEach(ticket => {
       const card = createTicketCard(ticket);
       resultContainer.appendChild(card);
     });
-    });
+
+    const totalPages = Math.ceil(count / PAGE_SIZE);
+    if (page < totalPages) {
+      loadMoreBtn.style.display = 'block';
+    } else {
+      loadMoreBtn.style.display = 'none';
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', fetchTickets);
+
+  loadMoreBtn.addEventListener('click', () => {
+    page += 1;
+    fetchTickets();
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Supabase Edge Function at `functions/tickets` with filtering and pagination
- change `tickets.html` to load ticket data from the new endpoint and provide a simple "load more" button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688219cc4db483238ca332400082ab19