### PR TITLE
Improve search and chips layout on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -181,6 +181,9 @@ main h2 {
 .search-container {
   margin: 3rem auto;
   text-align: center;
+  display: flex;
+  justify-content: center;
+  padding: 0 1rem;
 }
 
 #searchInput {
@@ -393,11 +396,11 @@ textarea {
 
 /* ===== Quick Chips ===== */
 .quick-chips{
-  display:flex;
-  gap:.5rem;
-  flex-wrap:wrap;
-  justify-content:center;
-  margin:1rem 0 1.25rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: .5rem;
+  justify-items: center;
+  margin: 1rem auto 1.25rem;
 }
 
 .chip{
@@ -428,4 +431,15 @@ textarea {
   height:auto !important;   /* 높이 강제 비율 유지 */
   top:50px;
   filter:drop-shadow(0 4px 12px rgba(0,0,0,.12));
+}
+
+@media (max-width: 480px) {
+  .search-container {
+    margin: 1.5rem auto;
+  }
+
+  .quick-chips{
+    grid-template-columns: repeat(auto-fit, minmax(45%, 1fr));
+    padding: 0 .5rem;
+  }
 }


### PR DESCRIPTION
## Summary
- tweak `.search-container` with flex centering and padding
- change `.quick-chips` to use a grid layout
- add mobile media query for screens under 480px

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688219de38f48323a5087e314fac66a2