### PR TITLE
Add common header template

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,133 +15,7 @@
   </style>
 </head>
 <body>
-  <header>
-    <a href="index.html">
-      <img src="cover.png" alt="Ticket Zone Logo" class="home-logo" />
-    </a>
-    <nav>
-      <ul class="nav-links">
-        <li><a href="index.html">홈</a></li>
-        <li><a href="submit.html">티켓 등록</a></li>
-        <li><a href="about.html" class="active">소개</a></li>
-        <li class="dropdown">
-          <span class="dropdown-toggle">스포츠</span>
-          <ul class="dropdown-menu">
-            <li><strong>⚾ 야구</strong></li>
-            <li class="dropdown">
-            <span>두산 베어스</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/doosan/doosan_jamsil_weekday.html">잠실야구장(주중)</a></li>
-              <li><a href="baseball/doosan/doosan_jamsil_weekend.html">잠실야구장(금토일/공휴일)</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>LG 트윈스</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/lg/lg_jamsil_weekday.html">잠실야구장(주중)</a></li>
-              <li><a href="baseball/lg/lg_jamsil_weekend.html">잠실야구장(금토일/공휴일)</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>KT wiz</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/ktwiz/ktwiz_suwon_weekday.html">수원 위즈 파크(주중)</a></li>
-              <li><a href="baseball/ktwiz/ktwiz_suwon_weekend.html">수원 위즈 파크(금토일/공휴일)</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>삼성 라이온즈</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/samsung/samsung_daegu_weekday.html">대구 라이온즈 파크(주중)</a></li>
-              <li><a href="baseball/samsung/samsung_daegu_weekend.html">대구 라이온즈 파크(금토일/공휴일)</a></li>
-              <li><a href="baseball/samsung/samsung_pohang.html">포항 야구장</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>SSG 랜더스</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/ssg/ssg_incheon_weekday.html">인천 SSG 랜더스필드(주중)</a></li>
-              <li><a href="baseball/ssg/ssg_incheon_weekend.html">인천 SSG 랜더스필드(금토일/공휴일)</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>한화 이글스</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/hanwha/hanwha_daejeon_weekday.html">대전 한화생명 볼파크(주중)</a></li>
-              <li><a href="baseball/hanwha/hanwha_daejeon_weekend.html">대전 한화생명 볼파크(금토일/공휴일)</a></li>
-              <li><a href="baseball/hanwha/hanwha_cheongju.html">청주 야구장</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>NC 다이노스</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/nc/nc_ulsan_weekday.html">울산 문수 야구장(주중)</a></li>
-              <li><a href="baseball/nc/nc_ulsan_weekend.html">울산 문수 야구장(금토일/공휴일)</a></li>
-              <li><a href="baseball/nc/nc_changwon.html">창원 NC 파크</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>롯데 자이언츠</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/lotte/lotte_busan_weekday.html">부산 사직 야구장(주중)</a></li>
-              <li><a href="baseball/lotte/lotte_busan_weekend.html">부산 사직 야구장(금토일/공휴일)</a></li>
-              <li><a href="baseball/lotte/lotte_ulsan.html">울산 문수 야구장</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>키움 히어로즈</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/kiwoom/kiwoom_gocheok_weekday.html">고척 돔 야구장(주중)</a></li>
-              <li><a href="baseball/kiwoom/kiwoom_gocheok_weekend.html">고척 돔 야구장(금토일/공휴일)</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>KIA 타이거즈</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/kia/kia_gwangju_weekday.html">광주 챔피언스 필드(주중)</a></li>
-              <li><a href="baseball/kia/kia_gwangju_weekend.html">광주 챔피언스 필드(금토일/공휴일)</a></li>
-            </ul>
-          </li>
-            <li><strong>⚽ 축구</strong></li>
-            <li><a href="Soccer/fcseoul.html">FC 서울</a></li>
-            <li><a href="Soccer/suwonsamsung.html">수원 삼성</a></li>
-            <li><a href="Soccer/ulsanhyundai.html">울산 현대</a></li>
-            <li><a href="Soccer/jeonbuk.html">전북 현대</a></li>
-            <li><a href="Soccer/pohang.html">포항 스틸러스</a></li>
-            <li><a href="Soccer/daegu.html">대구 FC</a></li>
-            <li><a href="Soccer/gwangju.html">광주 FC</a></li>
-            <li><a href="Soccer/jeju.html">제주 유나이티드</a></li>
-            <li><a href="Soccer/incheon.html">인천 유나이티드</a></li>
-            <li><a href="Soccer/gangwon.html">강원 FC</a></li>
-          </ul>
-        </li>
-        <style>
-          .nav-links li { position: relative; }
-          .dropdown-menu, .sub-dropdown-menu {
-            display: none;
-            position: absolute;
-            top: 100%;
-            left: 0;
-            background: white;
-            border: 1px solid #ccc;
-            z-index: 1000;
-            white-space: nowrap;
-          }
-          .dropdown:hover > .dropdown-menu {
-            display: block;
-          }
-          .dropdown-menu li:hover > .sub-dropdown-menu {
-            display: block;
-            top: 0;
-            left: 100%;
-          }
-          .dropdown-menu li {
-            position: relative;
-          }
-        </style>
-      </ul>
-    </nav>
-  </header>
+<div id="header-placeholder"></div>
 
   <main class="about-container">
     <h2>Ticket Zone 플랫폼 소개</h2>
@@ -163,5 +37,9 @@
   <footer>
     <p>&copy; 2025 Ticket Zone</p>
   </footer>
+<script type="module">
+  import { loadHeader } from "./headerLoader.js";
+  loadHeader("commonHeader.html");
+</script>
 </body>
 </html>

--- a/categories/sports.html
+++ b/categories/sports.html
@@ -41,45 +41,7 @@
   </style>
 </head>
 <body>
-  <header>
-    <h1>🎟️ Our Ticket</h1>
-    <nav>
-      <span>스포츠</span>
-      <div class="dropdown">
-        <div>
-          <strong>야구</strong><br>
-          <span>두산 베어스</span><button onclick="toggleSubmenu('doosan')">+</button>
-          <div id="doosan" class="submenu">
-            <div>잠실야구장 (주중)</div>
-            <div>잠실야구장 (주말)</div>
-          </div>
-          <span>LG 트윈스</span><button onclick="toggleSubmenu('lg')">+</button>
-          <div id="lg" class="submenu">
-            <div>잠실야구장 (주중)</div>
-            <div>잠실야구장 (주말)</div>
-          </div>
-          <span>KT wiz</span><button onclick="toggleSubmenu('kt')">+</button>
-          <div id="kt" class="submenu">
-            <div>수원KT위즈파크 (주중)</div>
-            <div>수원KT위즈파크 (주말)</div>
-          </div>
-          <!-- 다른 KBO 구단도 동일하게 추가 -->
-        </div>
-        <div>
-          <strong>축구</strong><br>
-          <span>FC 서울</span><button onclick="toggleSubmenu('fcseoul')">+</button>
-          <div id="fcseoul" class="submenu">
-            <div>서울월드컵경기장</div>
-          </div>
-          <span>수원 삼성</span><button onclick="toggleSubmenu('suwon')">+</button>
-          <div id="suwon" class="submenu">
-            <div>수원월드컵경기장</div>
-          </div>
-          <!-- 다른 K리그1 구단도 동일하게 추가 -->
-        </div>
-      </div>
-    </nav>
-  </header>
+<div id="header-placeholder"></div>
 
   <script>
     function toggleSubmenu(id) {
@@ -87,5 +49,9 @@
       el.style.display = el.style.display === 'block' ? 'none' : 'block';
     }
   </script>
+<script type="module">
+  import { loadHeader } from "../headerLoader.js";
+  loadHeader("../commonHeader.html");
+</script>
 </body>
 </html>

--- a/commonHeader.html
+++ b/commonHeader.html
@@ -1,0 +1,127 @@
+<header>
+  <a href="/index.html">
+    <img src="/cover.png" alt="Ticket Zone Logo" class="home-logo" />
+  </a>
+  <nav>
+    <ul class="nav-links">
+      <li><a href="/submit.html">티켓 등록</a></li>
+      <li><a href="/tickets.html">등록된 티켓</a></li>
+      <li><a href="/about.html">소개</a></li>
+      <li class="dropdown">
+        <span class="dropdown-toggle">스포츠</span>
+        <ul class="dropdown-menu">
+          <li><strong>⚾ 야구</strong></li>
+          <li class="dropdown">
+            <span>두산 베어스</span>
+            <ul class="sub-dropdown-menu">
+              <li><a href="/baseball/doosan/doosan_jamsil_weekday.html">잠실야구장(주중)</a></li>
+              <li><a href="/baseball/doosan/doosan_jamsil_weekend.html">잠실야구장(금토일/공휴일)</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <span>LG 트윈스</span>
+            <ul class="sub-dropdown-menu">
+              <li><a href="/baseball/lg/lg_jamsil_weekday.html">잠실야구장(주중)</a></li>
+              <li><a href="/baseball/lg/lg_jamsil_weekend.html">잠실야구장(금토일/공휴일)</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <span>KT wiz</span>
+            <ul class="sub-dropdown-menu">
+              <li><a href="/baseball/ktwiz/ktwiz_suwon_weekday.html">수원 위즈 파크(주중)</a></li>
+              <li><a href="/baseball/ktwiz/ktwiz_suwon_weekend.html">수원 위즈 파크(금토일/공휴일)</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <span>삼성 라이온즈</span>
+            <ul class="sub-dropdown-menu">
+              <li><a href="/baseball/samsung/samsung_daegu_weekday.html">대구 라이온즈 파크(주중)</a></li>
+              <li><a href="/baseball/samsung/samsung_daegu_weekend.html">대구 라이온즈 파크(금토일/공휴일)</a></li>
+              <li><a href="/baseball/samsung/samsung_pohang.html">포항 야구장</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <span>SSG 랜더스</span>
+            <ul class="sub-dropdown-menu">
+              <li><a href="/baseball/ssg/ssg_incheon_weekday.html">인천 SSG 랜더스필드(주중)</a></li>
+              <li><a href="/baseball/ssg/ssg_incheon_weekend.html">인천 SSG 랜더스필드(금토일/공휴일)</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <span>한화 이글스</span>
+            <ul class="sub-dropdown-menu">
+              <li><a href="/baseball/hanwha/hanwha_daejeon_weekday.html">대전 한화생명 볼파크(주중)</a></li>
+              <li><a href="/baseball/hanwha/hanwha_daejeon_weekend.html">대전 한화생명 볼파크(금토일/공휴일)</a></li>
+              <li><a href="/baseball/hanwha/hanwha_cheongju.html">청주 야구장</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <span>NC 다이노스</span>
+            <ul class="sub-dropdown-menu">
+              <li><a href="/baseball/nc/nc_ulsan_weekday.html">울산 문수 야구장(주중)</a></li>
+              <li><a href="/baseball/nc/nc_ulsan_weekend.html">울산 문수 야구장(금토일/공휴일)</a></li>
+              <li><a href="/baseball/nc/nc_changwon.html">창원 NC 파크</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <span>롯데 자이언츠</span>
+            <ul class="sub-dropdown-menu">
+              <li><a href="/baseball/lotte/lotte_busan_weekday.html">부산 사직 야구장(주중)</a></li>
+              <li><a href="/baseball/lotte/lotte_busan_weekend.html">부산 사직 야구장(금토일/공휴일)</a></li>
+              <li><a href="/baseball/lotte/lotte_ulsan.html">울산 문수 야구장</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <span>키움 히어로즈</span>
+            <ul class="sub-dropdown-menu">
+              <li><a href="/baseball/kiwoom/kiwoom_gocheok_weekday.html">고척 돔 야구장(주중)</a></li>
+              <li><a href="/baseball/kiwoom/kiwoom_gocheok_weekend.html">고척 돔 야구장(금토일/공휴일)</a></li>
+            </ul>
+          </li>
+          <li class="dropdown">
+            <span>KIA 타이거즈</span>
+            <ul class="sub-dropdown-menu">
+              <li><a href="/baseball/kia/kia_gwangju_weekday.html">광주 챔피언스 필드(주중)</a></li>
+              <li><a href="/baseball/kia/kia_gwangju_weekend.html">광주 챔피언스 필드(금토일/공휴일)</a></li>
+            </ul>
+          </li>
+          <li><strong>⚽ 축구</strong></li>
+          <li><a href="/Soccer/fcseoul.html">FC 서울</a></li>
+          <li><a href="/Soccer/suwonsamsung.html">수원 삼성</a></li>
+          <li><a href="/Soccer/ulsanhyundai.html">울산 현대</a></li>
+          <li><a href="/Soccer/jeonbuk.html">전북 현대</a></li>
+          <li><a href="/Soccer/pohang.html">포항 스틸러스</a></li>
+          <li><a href="/Soccer/daegu.html">대구 FC</a></li>
+          <li><a href="/Soccer/gwangju.html">광주 FC</a></li>
+          <li><a href="/Soccer/jeju.html">제주 유나이티드</a></li>
+          <li><a href="/Soccer/incheon.html">인천 유나이티드</a></li>
+          <li><a href="/Soccer/gangwon.html">강원 FC</a></li>
+        </ul>
+      </li>
+      <style>
+        .nav-links li { position: relative; }
+        .dropdown-menu, .sub-dropdown-menu {
+          display: none;
+          position: absolute;
+          top: 100%;
+          left: 0;
+          background: white;
+          border: 1px solid #ccc;
+          z-index: 1000;
+          white-space: nowrap;
+        }
+        .dropdown:hover > .dropdown-menu {
+          display: block;
+        }
+        .dropdown-menu li:hover > .sub-dropdown-menu {
+          display: block;
+          top: 0;
+          left: 100%;
+        }
+        .dropdown-menu li {
+          position: relative;
+        }
+      </style>
+    </ul>
+  </nav>
+</header>

--- a/index.html
+++ b/index.html
@@ -140,13 +140,7 @@
   padding: 10px 16px; background-color: #007BFF; color: white; text-decoration: none; border-radius: 6px;">
   로그인 / 회원가입
 </a>
-<header>
-<a href="index.html">
-<img alt="Ticket Zone Logo" class="home-logo_index" src="cover.png"/>
-</a>
-<nav>
-</nav>
-</header>
+<div id="header-placeholder"></div>
 <main><section class="hero-banner"><h2>실시간 티켓 거래, 믿을 수 있는 Ticket Zone</h2>
     <p>야구/축구 티켓을 쉽고 빠르게 등록하고 양도해보세요.</p>
 <div class="cta-group">
@@ -363,5 +357,9 @@ function toggleSub(el) {
     submenu.style.display = submenu.style.display === "block" ? "none" : "block";
   }
 }
+<script type="module">
+  import { loadHeader } from "./headerLoader.js";
+  loadHeader("commonHeader.html");
+</script>
 </script></body>
 </html>

--- a/login.html
+++ b/login.html
@@ -8,11 +8,7 @@
 <body>
   <div class="login-wrapper">
 
-  <header style="width: 100%; padding: 16px 0; border-bottom: 1px solid #eee; margin-bottom: 24px;">
-    <a href="index.html" style="text-decoration: none; color: #4a90e2; font-weight: bold; font-size: 18px;">
-      ← 홈으로 돌아가기
-    </a>
-  </header>
+<div id="header-placeholder"></div>
 
   <h1>로그인</h1>
 
@@ -204,5 +200,9 @@
     });
   </script>
   </div>
+<script type="module">
+  import { loadHeader } from "./headerLoader.js";
+  loadHeader("commonHeader.html");
+</script>
 </body>
 </html>

--- a/mypage.html
+++ b/mypage.html
@@ -40,17 +40,7 @@
 <body>
 
   
-  <header style="display: flex; justify-content: space-between; align-items: center; padding: 10px;">
-    <div>
-      <a href="index.html" style="text-decoration: none; font-size: 24px;">🎟️</a>
-    </div>
-    <h1 style="margin: 0; text-align: center; flex-grow: 1;">마이페이지</h1>
-    <nav class="nav-links" style="display: flex; gap: 10px;">
-      <a href="submit.html">티켓 등록</a>
-      <a href="tickets.html">등록된 티켓</a>
-      <a href="about.html">소개</a>
-    </nav>
-  </header>
+<div id="header-placeholder"></div>
 
 
   
@@ -135,6 +125,10 @@
   <div class="info" id="user-info">불러오는 중...</div>
   <button class="logout-btn" id="logout-btn">로그아웃</button>
   <div class="info" id="account-section">계좌 정보를 불러오는 중...</div>
+<script type="module">
+  import { loadHeader } from "./headerLoader.js";
+  loadHeader("commonHeader.html");
+</script>
 </body>
 
 </html>

--- a/tickets.html
+++ b/tickets.html
@@ -69,136 +69,7 @@
 </head>
 
 <body>
-<header>
-  <a href="index.html">
-    <img src="cover.png" alt="Ticket Zone Logo" class="home-logo" />
-  </a>
-  <nav>
-    <ul class="nav-links">
-      <li><a href="/submit.html">티켓 등록</a></li>
-      <li><a href="/tickets.html">등록된 티켓</a></li>
-      <li><a href="/about.html">소개</a></li>
-      <li class="dropdown">
-        <span class="dropdown-toggle">스포츠</span>
-        <ul class="dropdown-menu">
-          <li><strong>⚾ 야구</strong></li>
-          <li class="dropdown">
-            <span>두산 베어스</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/doosan/doosan_jamsil_weekday.html">잠실야구장(주중)</a></li>
-              <li><a href="baseball/doosan/doosan_jamsil_weekend.html">잠실야구장(금토일/공휴일)</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>LG 트윈스</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/lg/lg_jamsil_weekday.html">잠실야구장(주중)</a></li>
-              <li><a href="baseball/lg/lg_jamsil_weekend.html">잠실야구장(금토일/공휴일)</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>KT wiz</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/ktwiz/ktwiz_suwon_weekday.html">수원 위즈 파크(주중)</a></li>
-              <li><a href="baseball/ktwiz/ktwiz_suwon_weekend.html">수원 위즈 파크(금토일/공휴일)</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>삼성 라이온즈</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/samsung/samsung_daegu_weekday.html">대구 라이온즈 파크(주중)</a></li>
-              <li><a href="baseball/samsung/samsung_daegu_weekend.html">대구 라이온즈 파크(금토일/공휴일)</a></li>
-              <li><a href="baseball/samsung/samsung_pohang.html">포항 야구장</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>SSG 랜더스</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/ssg/ssg_incheon_weekday.html">인천 SSG 랜더스필드(주중)</a></li>
-              <li><a href="baseball/ssg/ssg_incheon_weekend.html">인천 SSG 랜더스필드(금토일/공휴일)</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>한화 이글스</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/hanwha/hanwha_daejeon_weekday.html">대전 한화생명 볼파크(주중)</a></li>
-              <li><a href="baseball/hanwha/hanwha_daejeon_weekend.html">대전 한화생명 볼파크(금토일/공휴일)</a></li>
-              <li><a href="baseball/hanwha/hanwha_cheongju.html">청주 야구장</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>NC 다이노스</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/nc/nc_ulsan_weekday.html">울산 문수 야구장(주중)</a></li>
-              <li><a href="baseball/nc/nc_ulsan_weekend.html">울산 문수 야구장(금토일/공휴일)</a></li>
-              <li><a href="baseball/nc/nc_changwon.html">창원 NC 파크</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>롯데 자이언츠</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/lotte/lotte_busan_weekday.html">부산 사직 야구장(주중)</a></li>
-              <li><a href="baseball/lotte/lotte_busan_weekend.html">부산 사직 야구장(금토일/공휴일)</a></li>
-              <li><a href="baseball/lotte/lotte_ulsan.html">울산 문수 야구장</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>키움 히어로즈</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/kiwoom/kiwoom_gocheok_weekday.html">고척 돔 야구장(주중)</a></li>
-              <li><a href="baseball/kiwoom/kiwoom_gocheok_weekend.html">고척 돔 야구장(금토일/공휴일)</a></li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <span>KIA 타이거즈</span>
-            <ul class="sub-dropdown-menu">
-              <li><a href="baseball/kia/kia_gwangju_weekday.html">광주 챔피언스 필드(주중)</a></li>
-              <li><a href="baseball/kia/kia_gwangju_weekend.html">광주 챔피언스 필드(금토일/공휴일)</a></li>
-            </ul>
-          </li>
-          <li><strong>⚽ 축구</strong></li>
-          <li><a href="Soccer/fcseoul.html">FC 서울</a></li>
-          <li><a href="Soccer/suwonsamsung.html">수원 삼성</a></li>
-          <li><a href="Soccer/ulsanhyundai.html">울산 현대</a></li>
-          <li><a href="Soccer/jeonbuk.html">전북 현대</a></li>
-          <li><a href="Soccer/pohang.html">포항 스틸러스</a></li>
-          <li><a href="Soccer/daegu.html">대구 FC</a></li>
-          <li><a href="Soccer/gwangju.html">광주 FC</a></li>
-          <li><a href="Soccer/jeju.html">제주 유나이티드</a></li>
-          <li><a href="Soccer/incheon.html">인천 유나이티드</a></li>
-          <li><a href="Soccer/gangwon.html">강원 FC</a></li>
-        </ul>
-      </li>
-      
-      <style>
-        .nav-links li { position: relative; }
-        .dropdown-menu, .sub-dropdown-menu {
-          display: none;
-          position: absolute;
-          top: 100%;
-          left: 0;
-          background: white;
-          border: 1px solid #ccc;
-          z-index: 1000;
-          white-space: nowrap;
-        }
-        .dropdown:hover > .dropdown-menu {
-          display: block;
-        }
-        .dropdown-menu li:hover > .sub-dropdown-menu {
-          display: block;
-          top: 0;
-          left: 100%;
-        }
-        .dropdown-menu li {
-          position: relative;
-        }
-      </style>
-      </ul>
-            </li>
-          </ul>
-      </nav>
-</header>
+<div id="header-placeholder"></div>
 <h1>티켓 목록</h1>
 <div id="ticket-results">불러오는 중...</div>
 
@@ -231,6 +102,10 @@
       resultContainer.appendChild(card);
     });
     });
+</script>
+<script type="module">
+  import { loadHeader } from "./headerLoader.js";
+  loadHeader("commonHeader.html");
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create `commonHeader.html` template for site navigation
- swap inline headers with a shared header loaded via `loadHeader()`
- update root pages to use the new shared header

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688219e5f7488323baba66404f156e8b