### PR TITLE
Fix CAPTCHA gating for auth

### DIFF
--- a/login.html
+++ b/login.html
@@ -27,13 +27,14 @@
      data-callback="onTurnstileSuccess">
   </div>
     
-  <button id="login-btn">로그인</button>
+  <button id="login-btn" disabled>로그인</button>
     
   <script>
     let captchaToken = null;                // 전역 저장소
   
     function onTurnstileSuccess(token) {    // Turnstile 콜백
       captchaToken = token;
+      document.getElementById('login-btn').disabled = false;
     }
   </script>
   <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer></script>
@@ -95,6 +96,11 @@
     background-color: #4a90e2;
     color: white;
     transition: background-color 0.3s ease;
+  }
+
+  #login-btn:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
   }
 
   #login-btn:hover {
@@ -181,9 +187,14 @@
       const email = document.getElementById("email").value;
       const password = document.getElementById("password").value;
 
+      const result = document.getElementById("result");
+      if (!captchaToken) {
+        result.textContent = "❌ CAPTCHA를 완료해 주세요.";
+        return;
+      }
+
       const { error } = await supabase.auth.signInWithPassword({ email, password, options: { captchaToken } });
 
-      const result = document.getElementById("result");
       if (error) {
         result.textContent = "❌ 로그인 실패: " + error.message;
       } else {

--- a/signup.html
+++ b/signup.html
@@ -43,6 +43,11 @@
     cursor: pointer;
     margin-top: 12px;
   }
+
+  button:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
+  }
   button:hover {
     background-color: #0056b3;
   }
@@ -163,12 +168,13 @@
 </div>
 
 
-  <button id="signup-btn">회원가입</button>
+  <button id="signup-btn" disabled>회원가입</button>
   <script>
     let captchaToken = null;                // 전역 저장소
   
     function onTurnstileSuccess(token) {    // Turnstile 콜백
       captchaToken = token;
+      document.getElementById('signup-btn').disabled = false;
     }
   </script>
   <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer></script>
@@ -243,6 +249,11 @@
 
       if (password !== passwordConfirm) {
         result.textContent = "❌ 비밀번호가 일치하지 않습니다.";
+        return;
+      }
+
+      if (!captchaToken) {
+        result.textContent = "❌ CAPTCHA를 완료해 주세요.";
         return;
       }
 


### PR DESCRIPTION
## Summary
- disable login and signup buttons by default
- enable them once Turnstile verifies
- block auth attempts until CAPTCHA token is available

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888696900b08323824386b0ecf1435e