### PR TITLE
Fix login after failed attempt

### DIFF
--- a/login.html
+++ b/login.html
@@ -194,6 +194,10 @@
       }
 
       const { error } = await supabase.auth.signInWithPassword({ email, password, options: { captchaToken } });
+      // Turnstile tokens are single-use, so always reset after an attempt
+      turnstile.reset('#turnstile-widget');
+      captchaToken = null;
+      document.getElementById('login-btn').disabled = true;
 
       if (error) {
         result.textContent = "❌ 로그인 실패: " + error.message;


### PR DESCRIPTION
## Summary
- reset Cloudflare Turnstile widget after every login attempt
- disable login button until captcha is solved again

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68887daf2a3c832391b2ee3fdc8beb9a