### PR TITLE
Switch env.js to ESM exports

### DIFF
--- a/env.js
+++ b/env.js
@@ -1,2 +1,2 @@
-window.SUPABASE_URL      = 'https://dbdnvjbkotlyarsfmtjn.supabase.co';
-window.SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRiZG52amJrb3RseWFyc2ZtdGpuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY5NTUxNTUsImV4cCI6MjA2MjUzMTE1NX0.cQXd9NQQbEQ5tWAeQ2pJWIoGkQjAbVs4tOQAUeDCET0';
+export const SUPABASE_URL = 'https://dbdnvjbkotlyarsfmtjn.supabase.co';
+export const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRiZG52amJrb3RseWFyc2ZtdGpuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY5NTUxNTUsImV4cCI6MjA2MjUzMTE1NX0.cQXd9NQQbEQ5tWAeQ2pJWIoGkQjAbVs4tOQAUeDCET0';


### PR DESCRIPTION
## Summary
- use ES module exports in `env.js`
- keep `supabaseClient.js` import of env variables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a4445c88c83238ff06d9079dfa50f