### PR TITLE
refactor: move auth page styles to stylesheet

### DIFF
--- a/login.html
+++ b/login.html
@@ -4,8 +4,9 @@
 <head>
   <meta charset="UTF-8" />
   <title>Ticket Zone 로그인</title>
+  <link rel="stylesheet" href="style.css" />
 </head>
-<body>
+<body class="auth-page login-page">
   <div class="login-wrapper">
 
   <header style="width: 100%; padding: 16px 0; border-bottom: 1px solid #eee; margin-bottom: 24px;">
@@ -40,144 +41,15 @@
   <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer></script>
 
 
-  <hr/>
-
-<style>
-  body {
-    font-family: 'Segoe UI', sans-serif;
-    background-color: #f7f9fc;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
-    margin: 0;
-  }
-
-  .login-wrapper {
-    background: white;
-    padding: 40px 30px;
-    border-radius: 12px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
-    width: 100%;
-    max-width: 400px;
-    box-sizing: border-box;
-    text-align: center;
-  }
-
-  h1 {
-    margin-bottom: 24px;
-    font-size: 24px;
-    color: #333;
-  }
-
-  input[type="email"],
-  input[type="password"] {
-    width: 100%;
-    padding: 12px;
-    margin: 8px 0;
-    border: 1px solid #ccc;
-    border-radius: 8px;
-    font-size: 14px;
-    box-sizing: border-box;
-  }
-
-  button {
-    width: 100%;
-    padding: 12px;
-    margin-top: 12px;
-    font-size: 16px;
-    border: none;
-    border-radius: 8px;
-    cursor: pointer;
-    font-weight: bold;
-  }
-
-  #login-btn {
-    background-color: #4a90e2;
-    color: white;
-    transition: background-color 0.3s ease;
-  }
-
-  #login-btn:disabled {
-    background-color: #ccc;
-    cursor: not-allowed;
-  }
-
-  #login-btn:hover {
-    background-color: #357ab8;
-  }
-
-  .google-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 12px;
-    padding: 12px 24px;
-    background-color: #ffffff;
-    color: #000000;
-    border: 1px solid #dadce0;
-    border-radius: 8px;
-    font-size: 16px;
-    font-weight: 500;
-    font-family: 'Segoe UI', sans-serif;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    width: 100%;
-    margin-top: 10px;
-    justify-content: center;
-  }
-
-  .google-btn:hover {
-    background-color: #f1f3f4;
-    transform: translateY(-1px);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-  }
-
-  .google-icon {
-    width: 20px;
-    height: 20px;
-  }
-
-  .signup-link {
-    margin-top: 16px;
-    display: block;
-    text-align: center;
-    font-size: 14px;
-  }
-
-  #result {
-    margin-top: 16px;
-    font-size: 14px;
-    color: #d9534f;
-  }
-</style>
-
-<style>
-  .google-btn {
-    display: inline-flex; align-items: center; gap: 12px;
-    padding: 12px 24px; background-color: #ffffff; color: #000000;
-    border: 1px solid #dadce0; border-radius: 8px; font-size: 16px;
-    font-weight: 500; font-family: "Segoe UI", sans-serif;
-    cursor: pointer; transition: all 0.3s ease;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  }
-  .google-btn:hover {
-    background-color: #f1f3f4; transform: translateY(-1px);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-  }
-  .google-icon { width: 20px; height: 20px; }
-</style>
-
+<hr/>
 <button id="google-login" class="google-btn">
   <img class="google-icon" src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" alt="Google logo">
   Google 계정으로 로그인
 </button>
 
-  <div style="margin-top: 10px; text-align: center;">
-    <a href="signup.html">아직 회원이 아니신가요? 회원가입</a>
-  </div>
+    <a class="signup-link" href="signup.html">아직 회원이 아니신가요? 회원가입</a>
 
-  <div id="result"></div>
+  <div id="result" class="auth-result"></div>
 
   <script type="module">
     import { supabase } from './supabaseClient.js';

--- a/signup.html
+++ b/signup.html
@@ -1,152 +1,12 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-
-<style>
-  body {
-    font-family: 'Segoe UI', sans-serif;
-    background-color: #f4f4f4;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
-  }
-  .container {
-    background: white;
-    padding: 40px;
-    border-radius: 16px;
-    box-shadow: 0 0 20px rgba(0,0,0,0.1);
-    width: 100%;
-    max-width: 400px;
-  }
-  h2 {
-    text-align: center;
-    margin-bottom: 20px;
-    color: #333;
-  }
-  input[type="email"], input[type="password"], input[type="text"], input[type="date"] {
-    width: 100%;
-    padding: 12px;
-    margin: 8px 0;
-    box-sizing: border-box;
-    border-radius: 8px;
-    border: 1px solid #ccc;
-  }
-  button {
-    width: 100%;
-    padding: 12px;
-    background-color: #007BFF;
-    border: none;
-    color: white;
-    font-weight: bold;
-    border-radius: 8px;
-    cursor: pointer;
-    margin-top: 12px;
-  }
-
-  button:disabled {
-    background-color: #ccc;
-    cursor: not-allowed;
-  }
-  button:hover {
-    background-color: #0056b3;
-  }
-  .home-link {
-    display: block;
-    text-align: center;
-    margin-top: 20px;
-    color: #007BFF;
-    text-decoration: none;
-  }
-  .home-link:hover {
-    text-decoration: underline;
-  }
-  #result {
-    text-align: center;
-    margin-top: 12px;
-  }
-
-.checkbox-group {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-top: 10px;
-}
-.checkbox-group label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.checkbox-group input[type="checkbox"] {
-  margin: 0;
-}
-
-
-.checkbox-group {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  margin-top: 10px;
-}
-.checkbox-group label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-}
-.checkbox-group input[type="checkbox"] {
-  margin: 0;
-}
-
-</style>
-
   <meta charset="UTF-8" />
   <title>회원가입</title>
-  <style>
-    body {
-      font-family: sans-serif;
-      max-width: 480px;
-      margin: 50px auto;
-      padding: 20px;
-      background: #f0f0f0;
-      border-radius: 12px;
-    }
-    h1 {
-      text-align: center;
-    }
-    input, button {
-      width: 100%;
-      padding: 10px;
-      margin-top: 10px;
-      border-radius: 6px;
-      border: 1px solid #ccc;
-      box-sizing: border-box;
-    }
-    button {
-      background-color: #007BFF;
-      color: white;
-      cursor: pointer;
-    }
-    label {
-      display: block;
-      margin-top: 10px;
-    }
-    .checkbox-group {
-      margin-top: 10px;
-    }
-    .checkbox-group input {
-      width: auto;
-    }
-    .info-note {
-      margin-top: 10px;
-      font-size: 13px;
-      color: #555;
-      text-align: center;
-    }
-  </style>
+  <link rel="stylesheet" href="style.css" />
 </head>
-<body>
-<div class="container">
+<body class="auth-page signup-page">
+<div class="signup-container">
 
   <h1>회원가입</h1>
 
@@ -192,7 +52,7 @@
     <a href="login.html">이미 계정이 있으신가요? 로그인</a>
   </div>
 
-  <div id="result"></div>
+  <div id="result" class="auth-result"></div>
 
   <script type="module">
     import { supabase } from './supabaseClient.js';
@@ -277,7 +137,7 @@
 
 </script>
 
-<a class="home-link" href="index.html">← 홈으로 돌아가기</a>
+  <a class="auth-home-link" href="index.html">← 홈으로 돌아가기</a>
 </div>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -429,3 +429,206 @@ textarea {
   top:50px;
   filter:drop-shadow(0 4px 12px rgba(0,0,0,.12));
 }
+
+/* Authentication pages */
+.auth-page {
+  font-family: 'Segoe UI', sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
+}
+
+.login-page {
+  background-color: #f7f9fc;
+}
+
+.signup-page {
+  background-color: #f4f4f4;
+}
+
+.login-wrapper {
+  background: white;
+  padding: 40px 30px;
+  border-radius: 12px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+  box-sizing: border-box;
+  text-align: center;
+}
+
+.login-wrapper h1 {
+  margin-bottom: 24px;
+  font-size: 24px;
+  color: #333;
+}
+
+.login-wrapper input[type="email"],
+.login-wrapper input[type="password"] {
+  width: 100%;
+  padding: 12px;
+  margin: 8px 0;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+
+.login-wrapper button {
+  width: 100%;
+  padding: 12px;
+  margin-top: 12px;
+  font-size: 16px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+#login-btn {
+  background-color: #4a90e2;
+  color: white;
+  transition: background-color 0.3s ease;
+}
+
+#login-btn:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+#login-btn:hover {
+  background-color: #357ab8;
+}
+
+.google-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 24px;
+  background-color: #ffffff;
+  color: #000000;
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 500;
+  font-family: 'Segoe UI', sans-serif;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  margin-top: 10px;
+  justify-content: center;
+}
+
+.google-btn:hover {
+  background-color: #f1f3f4;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.google-icon {
+  width: 20px;
+  height: 20px;
+}
+
+.signup-link {
+  margin-top: 16px;
+  display: block;
+  text-align: center;
+  font-size: 14px;
+}
+
+.auth-result {
+  margin-top: 16px;
+  font-size: 14px;
+  color: #d9534f;
+  text-align: center;
+}
+
+.signup-container {
+  background: white;
+  padding: 40px;
+  border-radius: 16px;
+  box-shadow: 0 0 20px rgba(0,0,0,0.1);
+  width: 100%;
+  max-width: 400px;
+}
+
+.signup-container h1 {
+  text-align: center;
+  margin-bottom: 20px;
+  color: #333;
+}
+
+.signup-container input[type="email"],
+.signup-container input[type="password"],
+.signup-container input[type="text"],
+.signup-container input[type="date"] {
+  width: 100%;
+  padding: 12px;
+  margin: 8px 0;
+  box-sizing: border-box;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+}
+
+.signup-container button {
+  width: 100%;
+  padding: 12px;
+  background-color: #007BFF;
+  border: none;
+  color: white;
+  font-weight: bold;
+  border-radius: 8px;
+  cursor: pointer;
+  margin-top: 12px;
+}
+
+.signup-container button:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+.signup-container button:hover {
+  background-color: #0056b3;
+}
+
+.auth-home-link {
+  display: block;
+  text-align: center;
+  margin-top: 20px;
+  color: #007BFF;
+  text-decoration: none;
+}
+
+.auth-home-link:hover {
+  text-decoration: underline;
+}
+
+.checkbox-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.checkbox-group label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+}
+
+.checkbox-group input[type="checkbox"] {
+  margin: 0;
+}
+
+.info-note {
+  margin-top: 10px;
+  font-size: 13px;
+  color: #555;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- extract login/signup inline styles into `style.css`
- link login and signup pages to shared stylesheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688dcb5d54f88323bcb73ab6e39c85d3