### PR TITLE
Refactor DOM updates to avoid innerHTML injections

### DIFF
--- a/Soccer/daegu.html
+++ b/Soccer/daegu.html
@@ -31,11 +31,13 @@
 
 <script type="module">
     import { supabase } from "../supabaseClient.js";
+    import { createSoccerTicket } from "../soccerTicket.js";
+    import { loadHeader } from "../headerLoader.js";
     const TEAM_NAME = '대구 FC';
 
     async function fetchTickets() {
       const list = document.getElementById('ticket-list');
-      list.innerHTML = '불러오는 중...';
+      list.textContent = '불러오는 중...';
 
       const { data, error } = await supabase
         .from('tickets')
@@ -44,42 +46,25 @@
 
       if (error) {
         console.error('에러:', error.message);
-        list.innerHTML = '데이터를 불러오는 중 오류가 발생했습니다.';
+        list.textContent = '데이터를 불러오는 중 오류가 발생했습니다.';
         return;
       }
 
       if (!data || data.length === 0) {
-        list.innerHTML = '등록된 티켓이 없습니다.';
+        list.textContent = '등록된 티켓이 없습니다.';
         return;
       }
 
-      list.innerHTML = ''; // 기존 내용 초기화
-
+      list.textContent = '';
       data.forEach(ticket => {
-        const div = document.createElement('div');
-        div.className = 'ticket';
-        div.innerHTML = `
-          <strong>경기 날짜:</strong> ${ticket.match_date} <br>
-          <strong>경기 시간:</strong> ${ticket.match_time}<br>
-          <strong>경기장:</strong> ${ticket.stadium}<br>
-          <strong>좌석 등급:</strong> ${ticket.seat_grade}<br>
-          <strong>좌석 번호:</strong> ${ticket.seat_number}<br>
-          <strong>티켓 당 가격:</strong> ${ticket.price}원<br>
-          <strong>판매 수량:</strong> ${ticket.ticket_count}장<br>
-          <strong>연락처:</strong> ${ticket.contact_method}<br>
-          <strong>추가 설명:</strong> ${ticket.additional_info || '없음'}
-        `;
+        const div = createSoccerTicket(ticket);
         list.appendChild(div);
       });
     }
 
     fetchTickets();
-    
-       fetch("../Soccer-header.html")
-      .then(response => response.text())
-      .then(data => {
-        document.getElementById("header-placeholder").innerHTML = data;
-      });
+
+    loadHeader('../Soccer-header.html');
   </script>
 </body>
 </html>

--- a/Soccer/gangwon.html
+++ b/Soccer/gangwon.html
@@ -31,11 +31,13 @@
 
   <script type="module">
     import { supabase } from "../supabaseClient.js";
+    import { createSoccerTicket } from "../soccerTicket.js";
+    import { loadHeader } from "../headerLoader.js";
     const TEAM_NAME = '강원 FC';
 
     async function fetchTickets() {
       const list = document.getElementById('ticket-list');
-      list.innerHTML = '불러오는 중...';
+      list.textContent = '불러오는 중...';
 
       const { data, error } = await supabase
         .from('tickets')
@@ -44,42 +46,25 @@
 
       if (error) {
         console.error('에러:', error.message);
-        list.innerHTML = '데이터를 불러오는 중 오류가 발생했습니다.';
+        list.textContent = '데이터를 불러오는 중 오류가 발생했습니다.';
         return;
       }
 
       if (!data || data.length === 0) {
-        list.innerHTML = '등록된 티켓이 없습니다.';
+        list.textContent = '등록된 티켓이 없습니다.';
         return;
       }
 
-      list.innerHTML = ''; // 기존 내용 초기화
-
+      list.textContent = '';
       data.forEach(ticket => {
-        const div = document.createElement('div');
-        div.className = 'ticket';
-        div.innerHTML = `
-          <strong>경기 날짜:</strong> ${ticket.match_date} <br>
-          <strong>경기 시간:</strong> ${ticket.match_time}<br>
-          <strong>경기장:</strong> ${ticket.stadium}<br>
-          <strong>좌석 등급:</strong> ${ticket.seat_grade}<br>
-          <strong>좌석 번호:</strong> ${ticket.seat_number}<br>
-          <strong>티켓 당 가격:</strong> ${ticket.price}원<br>
-          <strong>판매 수량:</strong> ${ticket.ticket_count}장<br>
-          <strong>연락처:</strong> ${ticket.contact_method}<br>
-          <strong>추가 설명:</strong> ${ticket.additional_info || '없음'}
-        `;
+        const div = createSoccerTicket(ticket);
         list.appendChild(div);
       });
     }
 
     fetchTickets();
-    
-       fetch("../Soccer-header.html")
-      .then(response => response.text())
-      .then(data => {
-        document.getElementById("header-placeholder").innerHTML = data;
-      });
+
+    loadHeader('../Soccer-header.html');
   </script>
 </body>
 </html>

--- a/Soccer/gwangju.html
+++ b/Soccer/gwangju.html
@@ -31,11 +31,13 @@
 
   <script type="module">
     import { supabase } from "../supabaseClient.js";
+    import { createSoccerTicket } from "../soccerTicket.js";
+    import { loadHeader } from "../headerLoader.js";
     const TEAM_NAME = '광주 FC';
 
     async function fetchTickets() {
       const list = document.getElementById('ticket-list');
-      list.innerHTML = '불러오는 중...';
+      list.textContent = '불러오는 중...';
 
       const { data, error } = await supabase
         .from('tickets')
@@ -44,42 +46,25 @@
 
       if (error) {
         console.error('에러:', error.message);
-        list.innerHTML = '데이터를 불러오는 중 오류가 발생했습니다.';
+        list.textContent = '데이터를 불러오는 중 오류가 발생했습니다.';
         return;
       }
 
       if (!data || data.length === 0) {
-        list.innerHTML = '등록된 티켓이 없습니다.';
+        list.textContent = '등록된 티켓이 없습니다.';
         return;
       }
 
-      list.innerHTML = ''; // 기존 내용 초기화
-
+      list.textContent = '';
       data.forEach(ticket => {
-        const div = document.createElement('div');
-        div.className = 'ticket';
-        div.innerHTML = `
-          <strong>경기 날짜:</strong> ${ticket.match_date} <br>
-          <strong>경기 시간:</strong> ${ticket.match_time}<br>
-          <strong>경기장:</strong> ${ticket.stadium}<br>
-          <strong>좌석 등급:</strong> ${ticket.seat_grade}<br>
-          <strong>좌석 번호:</strong> ${ticket.seat_number}<br>
-          <strong>티켓 당 가격:</strong> ${ticket.price}원<br>
-          <strong>판매 수량:</strong> ${ticket.ticket_count}장<br>
-          <strong>연락처:</strong> ${ticket.contact_method}<br>
-          <strong>추가 설명:</strong> ${ticket.additional_info || '없음'}
-        `;
+        const div = createSoccerTicket(ticket);
         list.appendChild(div);
       });
     }
 
     fetchTickets();
-    
-       fetch("../Soccer-header.html")
-      .then(response => response.text())
-      .then(data => {
-        document.getElementById("header-placeholder").innerHTML = data;
-      });
+
+    loadHeader('../Soccer-header.html');
   </script>
 </body>
 </html>

--- a/Soccer/incheon.html
+++ b/Soccer/incheon.html
@@ -31,11 +31,13 @@
 
   <script type="module">
     import { supabase } from "../supabaseClient.js";
+    import { createSoccerTicket } from "../soccerTicket.js";
+    import { loadHeader } from "../headerLoader.js";
     const TEAM_NAME = '인천 유나이티드';
 
     async function fetchTickets() {
       const list = document.getElementById('ticket-list');
-      list.innerHTML = '불러오는 중...';
+      list.textContent = '불러오는 중...';
 
       const { data, error } = await supabase
         .from('tickets')
@@ -44,42 +46,25 @@
 
       if (error) {
         console.error('에러:', error.message);
-        list.innerHTML = '데이터를 불러오는 중 오류가 발생했습니다.';
+        list.textContent = '데이터를 불러오는 중 오류가 발생했습니다.';
         return;
       }
 
       if (!data || data.length === 0) {
-        list.innerHTML = '등록된 티켓이 없습니다.';
+        list.textContent = '등록된 티켓이 없습니다.';
         return;
       }
 
-      list.innerHTML = ''; // 기존 내용 초기화
-
+      list.textContent = '';
       data.forEach(ticket => {
-        const div = document.createElement('div');
-        div.className = 'ticket';
-        div.innerHTML = `
-          <strong>경기 날짜:</strong> ${ticket.match_date} <br>
-          <strong>경기 시간:</strong> ${ticket.match_time}<br>
-          <strong>경기장:</strong> ${ticket.stadium}<br>
-          <strong>좌석 등급:</strong> ${ticket.seat_grade}<br>
-          <strong>좌석 번호:</strong> ${ticket.seat_number}<br>
-          <strong>티켓 당 가격:</strong> ${ticket.price}원<br>
-          <strong>판매 수량:</strong> ${ticket.ticket_count}장<br>
-          <strong>연락처:</strong> ${ticket.contact_method}<br>
-          <strong>추가 설명:</strong> ${ticket.additional_info || '없음'}
-        `;
+        const div = createSoccerTicket(ticket);
         list.appendChild(div);
       });
     }
 
     fetchTickets();
-    
-       fetch("../Soccer-header.html")
-      .then(response => response.text())
-      .then(data => {
-        document.getElementById("header-placeholder").innerHTML = data;
-      });
+
+    loadHeader('../Soccer-header.html');
   </script>
 </body>
 </html>

--- a/Soccer/jeju.html
+++ b/Soccer/jeju.html
@@ -31,11 +31,13 @@
 
   <script type="module">
     import { supabase } from "../supabaseClient.js";
+    import { createSoccerTicket } from "../soccerTicket.js";
+    import { loadHeader } from "../headerLoader.js";
     const TEAM_NAME = '제주 유나이티드';
 
     async function fetchTickets() {
       const list = document.getElementById('ticket-list');
-      list.innerHTML = '불러오는 중...';
+      list.textContent = '불러오는 중...';
 
       const { data, error } = await supabase
         .from('tickets')
@@ -44,42 +46,25 @@
 
       if (error) {
         console.error('에러:', error.message);
-        list.innerHTML = '데이터를 불러오는 중 오류가 발생했습니다.';
+        list.textContent = '데이터를 불러오는 중 오류가 발생했습니다.';
         return;
       }
 
       if (!data || data.length === 0) {
-        list.innerHTML = '등록된 티켓이 없습니다.';
+        list.textContent = '등록된 티켓이 없습니다.';
         return;
       }
 
-      list.innerHTML = ''; // 기존 내용 초기화
-
+      list.textContent = '';
       data.forEach(ticket => {
-        const div = document.createElement('div');
-        div.className = 'ticket';
-        div.innerHTML = `
-          <strong>경기 날짜:</strong> ${ticket.match_date} <br>
-          <strong>경기 시간:</strong> ${ticket.match_time}<br>
-          <strong>경기장:</strong> ${ticket.stadium}<br>
-          <strong>좌석 등급:</strong> ${ticket.seat_grade}<br>
-          <strong>좌석 번호:</strong> ${ticket.seat_number}<br>
-          <strong>티켓 당 가격:</strong> ${ticket.price}원<br>
-          <strong>판매 수량:</strong> ${ticket.ticket_count}장<br>
-          <strong>연락처:</strong> ${ticket.contact_method}<br>
-          <strong>추가 설명:</strong> ${ticket.additional_info || '없음'}
-        `;
+        const div = createSoccerTicket(ticket);
         list.appendChild(div);
       });
     }
 
     fetchTickets();
-    
-       fetch("../Soccer-header.html")
-      .then(response => response.text())
-      .then(data => {
-        document.getElementById("header-placeholder").innerHTML = data;
-      });
+
+    loadHeader('../Soccer-header.html');
   </script>
 </body>
 </html>

--- a/Soccer/jeonbuk.html
+++ b/Soccer/jeonbuk.html
@@ -31,11 +31,13 @@
 
   <script type="module">
     import { supabase } from "../supabaseClient.js";
+    import { createSoccerTicket } from "../soccerTicket.js";
+    import { loadHeader } from "../headerLoader.js";
     const TEAM_NAME = '전북 현대';
 
     async function fetchTickets() {
       const list = document.getElementById('ticket-list');
-      list.innerHTML = '불러오는 중...';
+      list.textContent = '불러오는 중...';
 
       const { data, error } = await supabase
         .from('tickets')
@@ -44,42 +46,25 @@
 
       if (error) {
         console.error('에러:', error.message);
-        list.innerHTML = '데이터를 불러오는 중 오류가 발생했습니다.';
+        list.textContent = '데이터를 불러오는 중 오류가 발생했습니다.';
         return;
       }
 
       if (!data || data.length === 0) {
-        list.innerHTML = '등록된 티켓이 없습니다.';
+        list.textContent = '등록된 티켓이 없습니다.';
         return;
       }
 
-      list.innerHTML = ''; // 기존 내용 초기화
-
+      list.textContent = '';
       data.forEach(ticket => {
-        const div = document.createElement('div');
-        div.className = 'ticket';
-        div.innerHTML = `
-          <strong>경기 날짜:</strong> ${ticket.match_date} <br>
-          <strong>경기 시간:</strong> ${ticket.match_time}<br>
-          <strong>경기장:</strong> ${ticket.stadium}<br>
-          <strong>좌석 등급:</strong> ${ticket.seat_grade}<br>
-          <strong>좌석 번호:</strong> ${ticket.seat_number}<br>
-          <strong>티켓 당 가격:</strong> ${ticket.price}원<br>
-          <strong>판매 수량:</strong> ${ticket.ticket_count}장<br>
-          <strong>연락처:</strong> ${ticket.contact_method}<br>
-          <strong>추가 설명:</strong> ${ticket.additional_info || '없음'}
-        `;
+        const div = createSoccerTicket(ticket);
         list.appendChild(div);
       });
     }
 
     fetchTickets();
-    
-       fetch("../Soccer-header.html")
-      .then(response => response.text())
-      .then(data => {
-        document.getElementById("header-placeholder").innerHTML = data;
-      });
+
+    loadHeader('../Soccer-header.html');
   </script>
 </body>
 </html>

--- a/Soccer/pohang.html
+++ b/Soccer/pohang.html
@@ -31,11 +31,13 @@
 
   <script type="module">
     import { supabase } from "../supabaseClient.js";
+    import { createSoccerTicket } from "../soccerTicket.js";
+    import { loadHeader } from "../headerLoader.js";
     const TEAM_NAME = '포항 스틸러스';
 
     async function fetchTickets() {
       const list = document.getElementById('ticket-list');
-      list.innerHTML = '불러오는 중...';
+      list.textContent = '불러오는 중...';
 
       const { data, error } = await supabase
         .from('tickets')
@@ -44,42 +46,25 @@
 
       if (error) {
         console.error('에러:', error.message);
-        list.innerHTML = '데이터를 불러오는 중 오류가 발생했습니다.';
+        list.textContent = '데이터를 불러오는 중 오류가 발생했습니다.';
         return;
       }
 
       if (!data || data.length === 0) {
-        list.innerHTML = '등록된 티켓이 없습니다.';
+        list.textContent = '등록된 티켓이 없습니다.';
         return;
       }
 
-      list.innerHTML = ''; // 기존 내용 초기화
-
+      list.textContent = '';
       data.forEach(ticket => {
-        const div = document.createElement('div');
-        div.className = 'ticket';
-        div.innerHTML = `
-          <strong>경기 날짜:</strong> ${ticket.match_date} <br>
-          <strong>경기 시간:</strong> ${ticket.match_time}<br>
-          <strong>경기장:</strong> ${ticket.stadium}<br>
-          <strong>좌석 등급:</strong> ${ticket.seat_grade}<br>
-          <strong>좌석 번호:</strong> ${ticket.seat_number}<br>
-          <strong>티켓 당 가격:</strong> ${ticket.price}원<br>
-          <strong>판매 수량:</strong> ${ticket.ticket_count}장<br>
-          <strong>연락처:</strong> ${ticket.contact_method}<br>
-          <strong>추가 설명:</strong> ${ticket.additional_info || '없음'}
-        `;
+        const div = createSoccerTicket(ticket);
         list.appendChild(div);
       });
     }
 
     fetchTickets();
-    
-       fetch("../Soccer-header.html")
-      .then(response => response.text())
-      .then(data => {
-        document.getElementById("header-placeholder").innerHTML = data;
-      });
+
+    loadHeader('../Soccer-header.html');
   </script>
 </body>
 </html>

--- a/Soccer/suwonsamsung.html
+++ b/Soccer/suwonsamsung.html
@@ -31,11 +31,13 @@
 
   <script type="module">
     import { supabase } from "../supabaseClient.js";
+    import { createSoccerTicket } from "../soccerTicket.js";
+    import { loadHeader } from "../headerLoader.js";
     const TEAM_NAME = '수원 삼성';
 
     async function fetchTickets() {
       const list = document.getElementById('ticket-list');
-      list.innerHTML = '불러오는 중...';
+      list.textContent = '불러오는 중...';
 
       const { data, error } = await supabase
         .from('tickets')
@@ -44,42 +46,25 @@
 
       if (error) {
         console.error('에러:', error.message);
-        list.innerHTML = '데이터를 불러오는 중 오류가 발생했습니다.';
+        list.textContent = '데이터를 불러오는 중 오류가 발생했습니다.';
         return;
       }
 
       if (!data || data.length === 0) {
-        list.innerHTML = '등록된 티켓이 없습니다.';
+        list.textContent = '등록된 티켓이 없습니다.';
         return;
       }
 
-      list.innerHTML = ''; // 기존 내용 초기화
-
+      list.textContent = '';
       data.forEach(ticket => {
-        const div = document.createElement('div');
-        div.className = 'ticket';
-        div.innerHTML = `
-          <strong>경기 날짜:</strong> ${ticket.match_date} <br>
-          <strong>경기 시간:</strong> ${ticket.match_time}<br>
-          <strong>경기장:</strong> ${ticket.stadium}<br>
-          <strong>좌석 등급:</strong> ${ticket.seat_grade}<br>
-          <strong>좌석 번호:</strong> ${ticket.seat_number}<br>
-          <strong>티켓 당 가격:</strong> ${ticket.price}원<br>
-          <strong>판매 수량:</strong> ${ticket.ticket_count}장<br>
-          <strong>연락처:</strong> ${ticket.contact_method}<br>
-          <strong>추가 설명:</strong> ${ticket.additional_info || '없음'}
-        `;
+        const div = createSoccerTicket(ticket);
         list.appendChild(div);
       });
     }
 
     fetchTickets();
-    
-       fetch("../Soccer-header.html")
-      .then(response => response.text())
-      .then(data => {
-        document.getElementById("header-placeholder").innerHTML = data;
-      });
+
+    loadHeader('../Soccer-header.html');
   </script>
 </body>
 </html>

--- a/mypage.html
+++ b/mypage.html
@@ -82,11 +82,18 @@
 
       const section = document.getElementById("account-section");
       if (section) {
+        section.textContent = '';
+        const p = document.createElement('p');
         if (account) {
-          section.innerHTML = `<p>계좌: ${account.bank_name} ${account.account_number} (${account.account_holder})</p>`;
+          p.textContent = `계좌: ${String(account.bank_name)} ${String(account.account_number)} (${String(account.account_holder)})`;
         } else {
-          section.innerHTML = `<p>계좌 미등록 상태입니다. <a href="account.html">등록하기</a></p>`;
+          p.append('계좌 미등록 상태입니다. ');
+          const link = document.createElement('a');
+          link.href = 'account.html';
+          link.textContent = '등록하기';
+          p.appendChild(link);
         }
+        section.appendChild(p);
       }
 
       }
@@ -118,16 +125,42 @@
         return;
       }
 
-      ticketList.innerHTML = "<h2>내 티켓 목록</h2>" + data.map(ticket => `
-        <div style="border: 1px solid #ccc; margin: 10px 0; padding: 10px; border-radius: 8px;">
-          <strong>${ticket.team}</strong> vs ${ticket.opponent_team}<br/>
-          경기장: ${ticket.stadium}<br/>
-          날짜: ${ticket.match_date} ${ticket.match_time}<br/>
-          <strong>좌석</strong><br/>
-          구역(존/블럭): ${ticket.section} 열: ${ticket.row}<br/>
-          가격: ₩${ticket.price} / 수량: ${ticket.ticket_count}
-        </div>
-      `).join("");
+      ticketList.textContent = '';
+      const heading = document.createElement('h2');
+      heading.textContent = '내 티켓 목록';
+      ticketList.appendChild(heading);
+
+      data.forEach(ticket => {
+        const div = document.createElement('div');
+        div.style.border = '1px solid #ccc';
+        div.style.margin = '10px 0';
+        div.style.padding = '10px';
+        div.style.borderRadius = '8px';
+
+        const teamStrong = document.createElement('strong');
+        teamStrong.textContent = String(ticket.team);
+        div.appendChild(teamStrong);
+        div.append(` vs ${String(ticket.opponent_team)}`);
+        div.appendChild(document.createElement('br'));
+
+        div.append(`경기장: ${String(ticket.stadium)}`);
+        div.appendChild(document.createElement('br'));
+
+        div.append(`날짜: ${String(ticket.match_date)} ${String(ticket.match_time)}`);
+        div.appendChild(document.createElement('br'));
+
+        const seatStrong = document.createElement('strong');
+        seatStrong.textContent = '좌석';
+        div.appendChild(seatStrong);
+        div.appendChild(document.createElement('br'));
+
+        div.append(`구역(존/블럭): ${String(ticket.section)} 열: ${String(ticket.row)}`);
+        div.appendChild(document.createElement('br'));
+
+        div.append(`가격: ₩${String(ticket.price)} / 수량: ${String(ticket.ticket_count)}`);
+
+        ticketList.appendChild(div);
+      });
     }
 
     loadUser();

--- a/payment.html
+++ b/payment.html
@@ -56,13 +56,29 @@ if (!ticketId) {
   if (error || !data) {
     infoDiv.textContent = '티켓을 불러오는 중 오류가 발생했습니다.';
   } else {
-    infoDiv.innerHTML = `
-      <h2>${data.team} vs ${data.opponent_team}</h2>
-      <p>${data.stadium}</p>
-      <p>${data.match_date} ${data.match_time}</p>
-      <p>${data.seat_grade} / ${data.section} / ${data.row}</p>
-      <p><strong>${Number(data.price).toLocaleString()}원</strong></p>
-    `;
+    infoDiv.textContent = '';
+    const title = document.createElement('h2');
+    title.textContent = `${data.team} vs ${data.opponent_team}`;
+    infoDiv.appendChild(title);
+
+    const stadiumP = document.createElement('p');
+    stadiumP.textContent = String(data.stadium);
+    infoDiv.appendChild(stadiumP);
+
+    const dateP = document.createElement('p');
+    dateP.textContent = `${String(data.match_date)} ${String(data.match_time)}`;
+    infoDiv.appendChild(dateP);
+
+    const seatP = document.createElement('p');
+    seatP.textContent = `${String(data.seat_grade)} / ${String(data.section)} / ${String(data.row)}`;
+    infoDiv.appendChild(seatP);
+
+    const priceP = document.createElement('p');
+    const strongPrice = document.createElement('strong');
+    strongPrice.textContent = `${Number(data.price).toLocaleString()}원`;
+    priceP.appendChild(strongPrice);
+    infoDiv.appendChild(priceP);
+
     purchaseBtn.style.display = 'inline-block';
   }
 }

--- a/soccerTicket.js
+++ b/soccerTicket.js
@@ -18,7 +18,7 @@ export function createSoccerTicket(ticket) {
     const strong = document.createElement('strong');
     strong.textContent = label;
     container.appendChild(strong);
-    container.append(` ${value}`);
+    container.append(` ${String(value ?? '')}`);
     if (index < fields.length - 1) {
       container.appendChild(document.createElement('br'));
     }


### PR DESCRIPTION
## Summary
- replace string-based DOM injection with element creation and textContent
- render soccer ticket pages via reusable helper and sanitized header loader
- sanitize Supabase fields before insertion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dcb5ee5ac8323a1a810579dd74baa