### PR TITLE
Validate ticket price and count and enforce DB constraints

### DIFF
--- a/submit.html
+++ b/submit.html
@@ -250,6 +250,7 @@
 <script src="notice.js"></script>
 <script type="module">
 import { supabase } from './supabaseClient.js';
+import { validateTicketInputs } from './validateTicketInputs.js';
 const isDev = window.location.hostname === 'localhost';
 
 updateSeatOptions("stadium_select", "seat_grade");
@@ -370,8 +371,15 @@ if (!seat_grade) {
   return;
 }
 const match_time = document.getElementById('match_time').value;
-      const price = parseInt(document.getElementById('price').value);
-      const ticket_count = parseInt(document.getElementById('ticket_count').value);
+      const validation = validateTicketInputs(
+        document.getElementById('price').value,
+        document.getElementById('ticket_count').value,
+        result
+      );
+      if (!validation) {
+        return;
+      }
+      const { price, ticket_count } = validation;
       
       const trade_method = document.getElementById('trade_method').value;
       const trade_description = document.getElementById('trade_description').value;

--- a/supabase/migrations/20240520_add_positive_constraints.sql
+++ b/supabase/migrations/20240520_add_positive_constraints.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tickets
+  ADD CONSTRAINT tickets_price_positive CHECK (price > 0),
+  ADD CONSTRAINT tickets_ticket_count_positive CHECK (ticket_count > 0);

--- a/tests/validateTicketInputs.test.js
+++ b/tests/validateTicketInputs.test.js
@@ -1,0 +1,33 @@
+import { validateTicketInputs } from '../validateTicketInputs.js';
+
+describe('validateTicketInputs', () => {
+  let resultEl;
+
+  beforeEach(() => {
+    resultEl = { textContent: '' };
+  });
+
+  test('shows error when price is empty', () => {
+    const valid = validateTicketInputs('', '1', resultEl);
+    expect(valid).toBe(false);
+    expect(resultEl.textContent).toBe('❌ 가격은 양의 정수를 입력해주세요.');
+  });
+
+  test('shows error when price contains letters', () => {
+    const valid = validateTicketInputs('abc', '1', resultEl);
+    expect(valid).toBe(false);
+    expect(resultEl.textContent).toBe('❌ 가격은 양의 정수를 입력해주세요.');
+  });
+
+  test('shows error when ticket count is empty', () => {
+    const valid = validateTicketInputs('1000', '', resultEl);
+    expect(valid).toBe(false);
+    expect(resultEl.textContent).toBe('❌ 수량은 양의 정수를 입력해주세요.');
+  });
+
+  test('shows error when ticket count contains letters', () => {
+    const valid = validateTicketInputs('1000', 'abc', resultEl);
+    expect(valid).toBe(false);
+    expect(resultEl.textContent).toBe('❌ 수량은 양의 정수를 입력해주세요.');
+  });
+});

--- a/validateTicketInputs.js
+++ b/validateTicketInputs.js
@@ -1,0 +1,15 @@
+export function validateTicketInputs(priceValue, countValue, resultEl) {
+  const price = parseInt(priceValue, 10);
+  if (Number.isNaN(price) || price <= 0) {
+    resultEl.textContent = '❌ 가격은 양의 정수를 입력해주세요.';
+    return false;
+  }
+
+  const ticket_count = parseInt(countValue, 10);
+  if (Number.isNaN(ticket_count) || ticket_count <= 0) {
+    resultEl.textContent = '❌ 수량은 양의 정수를 입력해주세요.';
+    return false;
+  }
+
+  return { price, ticket_count };
+}


### PR DESCRIPTION
## Summary
- validate ticket price and ticket count inputs with explicit checks
- block invalid price or count through database check constraints
- add tests ensuring empty or non-numeric values trigger error messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dcb5fcfe88323bd34a947cfe877ff